### PR TITLE
sidebar 컴포지션API 메뉴 중복 삭제

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -87,16 +87,6 @@ const sidebar = {
             '/guide/reactivity-computed-watchers'
           ]
         },
-        {
-          title: '컴포지션 API',
-          children: [
-            '/guide/composition-api-introduction',
-            '/guide/composition-api-setup',
-            '/guide/composition-api-lifecycle-hooks',
-            '/guide/composition-api-provide-inject',
-            '/guide/composition-api-template-refs'
-          ]
-        },
         '/guide/optimizations',
         '/guide/change-detection'
       ]


### PR DESCRIPTION
## Description of Problem
재사용성&컴포지션 타이틀과, 고급 가이드 타이틀 아래에 컴포지션 API 메뉴가 중복으로 되어 있습니다.

## Proposed Solution
원본 문서에 고급가이드 타이틀 아래 컴포지션 API 메뉴는 없어서 삭제하였습니다.

## Additional Information
