### PR TITLE
publish site on github pages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: publish
+
+on: 
+  push:
+    branches:
+    - rootKoKr
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+    - name: Install Dependencies
+      run: yarn
+    - name: Generate pages
+      run: yarn build
+    - name: Add CNAME
+      run: cat "v3.ko.vuejs.org" > src/.vurpress/dist/CNAME
+    - name: Deploy to GitHub Pages
+      uses: comfuture/actions/ghpages@master
+      env:
+        BUILD_DIR: src/.vuepress/dist/
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Generate pages
       run: yarn build
     - name: Add CNAME
-      run: cat "v3.ko.vuejs.org" > src/.vurpress/dist/CNAME
+      run: echo "v3.ko.vuejs.org" > src/.vurpress/dist/CNAME
     - name: Deploy to GitHub Pages
       uses: comfuture/actions/ghpages@master
       env:


### PR DESCRIPTION
## Description of Problem
Need to save hosting cost.

## Proposed Solution
Serves static generated vuepress site on github pages.
This script will runs every commit or merge on `rootKoKr` branch then pushes the result into `gh-pages` branch of this repository.

## Additional Information
- Need to change CNAME record of `v3.ko.vuejs.org` domain forward to `vuejs-kr.github.io.`
- Need to setup SSL on github pages section of settings.