### PR TITLE
레이아웃 등 기본 환경설정 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+pnpm-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
@@ -109,3 +110,33 @@ src/api/index.json
 src/examples/data.json
 src/tutorial/data.json
 draft.md
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Firebase cache
+.firebase/
+
+# add firebase gitignore ==================================
+# Logs
+firebase-debug.log*
+firebase-debug.*.log*
+node_modules
+/dist
+
+
+# local env files
+.env.local
+.env.*.local
+
+# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Bower dependency directory (https://bower.io/)
+bower_components

--- a/ko-KR/.vitepress/config.ts
+++ b/ko-KR/.vitepress/config.ts
@@ -14,9 +14,13 @@ const nav = [
       { text: '튜토리얼', link: '/tutorial/' },
       { text: '예제', link: '/examples/' },
       { text: '시작하기', link: '/guide/quick-start' },
-      { text: '스타일 가이드', link: '/style-guide/' },
+      // { text: 'Style Guide', link: '/style-guide/' },
       {
-        text: 'Vue 2에서 이전하기',
+        text: 'Vue 2 문서',
+        link: 'https://v2.vuejs.org'
+      },
+      {
+        text: 'Vue 2에서 마이그레이션',
         link: 'https://v3-migration.vuejs.org/'
       }
     ]
@@ -27,7 +31,7 @@ const nav = [
     link: '/api/'
   },
   {
-    text: 'Playground',
+    text: '온라인 연습장',
     link: 'https://sfc.vuejs.org'
   },
   {
@@ -35,12 +39,20 @@ const nav = [
     activeMatch: `^/ecosystem/`,
     items: [
       {
-        text: '자원',
+        text: '핵심 라이브러리',
         items: [
-          { text: '파트너', link: '/ecosystem/partners' },
-          { text: '테마', link: '/ecosystem/themes' },
-          { text: '구직 구인', link: 'https://vuejobs.com/?ref=vuejs' },
-          { text: '티 셔츠 샵', link: 'https://vue.threadless.com/' }
+          { text: 'Vue 라우터', link: 'https://router.vuejs.org/' },
+          { text: '피니아 (상태 관리)', link: 'https://pinia.vuejs.org/' }
+        ]
+      },
+      {
+        text: 'Resources',
+        items: [
+          { text: 'Sponsor', link: 'https://vuejs.org/sponsor/' },
+          { text: 'Partners', link: 'https://vuejs.org/partners/' },
+          { text: 'Themes', link: 'https://vuejs.org/ecosystem/themes' },
+          { text: 'Jobs', link: 'https://vuejobs.com/?ref=vuejs' },
+          { text: 'T-Shirt Shop', link: 'https://vue.threadless.com/' }
         ]
       },
       {
@@ -63,7 +75,10 @@ const nav = [
             text: 'Discord Chat',
             link: 'https://discord.com/invite/HBherRA'
           },
-          { text: 'Forum', link: 'https://forum.vuejs.org/' },
+          {
+            text: 'GitHub Discussions',
+            link: 'https://github.com/vuejs/core/discussions'
+          },
           { text: 'DEV Community', link: 'https://dev.to/t/vue' }
         ]
       },
@@ -83,23 +98,19 @@ const nav = [
     activeMatch: `^/about/`,
     items: [
       { text: 'FAQ', link: '/about/faq' },
-      { text: 'Team', link: '/about/team' },
-      { text: 'Releases', link: '/about/releases' },
+      { text: 'Team', link: 'https://vuejs.org/about/team' },
+      { text: 'Releases', link: 'https://vuejs.org/about/releases' },
       {
-        text: '커뮤니티 가이드',
-        link: '/about/community-guide'
+        text: 'Community Guide',
+        link: 'https://vuejs.org/about/community-guide'
       },
-      { text: 'Code of Conduct', link: '/about/coc' },
+      { text: 'Code of Conduct', link: 'https://vuejs.org/about/coc' },
       {
         text: 'The Documentary',
         link: 'https://www.youtube.com/watch?v=OrxmtDw4pVI'
       }
     ]
   },
-  {
-    text: '스폰서',
-    link: '/sponsor/'
-  }
 ]
 
 export const sidebar = {
@@ -107,7 +118,7 @@ export const sidebar = {
     {
       text: '시작하기',
       items: [
-        { text: '시작하기', link: '/guide/introduction' },
+        { text: '소개', link: '/guide/introduction' },
         {
           text: '빠른 시작',
           link: '/guide/quick-start'
@@ -118,7 +129,7 @@ export const sidebar = {
       text: '핵심 가이드',
       items: [
         {
-          text: '애플리케이션 만들기',
+          text: '앱 생성',
           link: '/guide/essentials/application'
         },
         {
@@ -153,15 +164,15 @@ export const sidebar = {
           link: '/guide/essentials/forms'
         },
         {
-          text: '생명주기 훅(Lifecycle Hooks)',
+          text: '수명주기 훅',
           link: '/guide/essentials/lifecycle'
         },
         {
-          text: '감시자(Watcher)',
+          text: '감시자',
           link: '/guide/essentials/watchers'
         },
         {
-          text: '템플릿 Refs',
+          text: '템플릿 참조',
           link: '/guide/essentials/template-refs'
         },
         {
@@ -178,12 +189,12 @@ export const sidebar = {
           link: '/guide/components/registration'
         },
         { text: 'Props', link: '/guide/components/props' },
-        { text: 'Events', link: '/guide/components/events' },
+        { text: '이벤트', link: '/guide/components/events' },
         {
-          text: 'Fallthrough Attributes',
+          text: '폴스루 속성',
           link: '/guide/components/attrs'
         },
-        { text: '슬롯(Slots)', link: '/guide/components/slots' },
+        { text: '슬롯', link: '/guide/components/slots' },
         {
           text: 'Provide / inject',
           link: '/guide/components/provide-inject'
@@ -378,7 +389,7 @@ export const sidebar = {
       ]
     },
     {
-      text: '내장',
+      text: '빌트-인',
       items: [
         { text: '디렉티브', link: '/api/built-in-directives' },
         { text: '컴포넌트', link: '/api/built-in-components' },
@@ -441,7 +452,7 @@ export const sidebar = {
       ]
     },
     {
-      text: '심Practical',
+      text: 'Practical',
       items: [
         {
           text: 'Markdown Editor',
@@ -601,10 +612,10 @@ export default defineConfigWithTheme<ThemeConfig>({
       }
     },
 
-    carbonAds: {
-      code: 'CEBDT27Y',
-      placement: 'vuejsorg'
-    },
+    // carbonAds: {
+    //   code: 'CEBDT27Y',
+    //   placement: 'vuejsorg'
+    // },
 
     socialLinks: [
       { icon: 'languages', link: '/translations/' },
@@ -613,10 +624,10 @@ export default defineConfigWithTheme<ThemeConfig>({
       { icon: 'discord', link: 'https://discord.com/invite/HBherRA' }
     ],
 
-    editLink: {
-      repo: 'vuejs/docs',
-      text: 'Edit this page on GitHub'
-    },
+    // editLink: {
+    //   repo: 'niceplugin/vue3-docs-ko',
+    //   text: 'GitHub에서 이 페이지 편집'
+    // },
 
     footer: {
       license: {

--- a/ko-KR/.vitepress/config.ts
+++ b/ko-KR/.vitepress/config.ts
@@ -624,10 +624,10 @@ export default defineConfigWithTheme<ThemeConfig>({
       { icon: 'discord', link: 'https://discord.com/invite/HBherRA' }
     ],
 
-    // editLink: {
-    //   repo: 'niceplugin/vue3-docs-ko',
-    //   text: 'GitHub에서 이 페이지 편집'
-    // },
+    editLink: {
+      repo: 'vuejs-kr/docs-next',
+      text: 'GitHub에서 이 페이지 편집'
+    },
 
     footer: {
       license: {

--- a/ko-KR/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/ko-KR/.vitepress/theme/components/PreferenceSwitch.vue
@@ -68,32 +68,29 @@ function useToggleFn(
       @mousedown="removeOutline"
       @blur="restoreOutline"
     >
-      <span>API Preference</span>
+      <span>API 스타일 설정</span>
       <VTIconChevronDown class="vt-link-icon" :class="{ open: isOpen }" />
     </button>
     <div id="preference-switches" :hidden="!isOpen" :aria-hidden="!isOpen">
       <div class="switch-container">
         <label class="options-label" @click="toggleCompositionAPI(false)"
-          >Options</label
-        >
+        >옵션</label>
         <VTSwitch
           class="api-switch"
-          aria-label="prefer composition api"
+          aria-label="컴포지션 api를 추천합니다"
           :aria-checked="preferComposition"
           @click="toggleCompositionAPI()"
         />
         <label
           class="composition-label"
           @click="toggleCompositionAPI(true)"
-          >Composition</label
-        >
+        >컴포지션</label>
         <a
           class="switch-link"
-          title="About API preference"
-          href="/guide/introduction.html#api-styles"
+          title="API 스타일에 대하여"
+          href="/guide/introduction.html#api-스타일"
           @click="closeSideBar"
-          >?</a
-        >
+        >?</a>
       </div>
       <div class="switch-container" v-if="showSFC">
         <label class="no-sfc-label" @click="toggleSFC(false)">HTML</label>
@@ -109,8 +106,7 @@ function useToggleFn(
           title="About SFC"
           href="/guide/scaling-up/sfc.html"
           @click="closeSideBar"
-          >?</a
-        >
+        >?</a>
       </div>
     </div>
   </div>

--- a/ko-KR/.vitepress/theme/index.ts
+++ b/ko-KR/.vitepress/theme/index.ts
@@ -1,31 +1,29 @@
 import './styles/index.css'
 import { h, App } from 'vue'
 import { VPTheme } from '@vue/theme'
-import Banner from './components/Banner.vue'
 import PreferenceSwitch from './components/PreferenceSwitch.vue'
-import VueSchoolLink from './components/VueSchoolLink.vue'
 import {
   preferComposition,
   preferSFC,
   filterHeadersByPreference
 } from './components/preferences'
 import SponsorsAside from './components/SponsorsAside.vue'
-import VueJobs from './components/VueJobs.vue'
+// import VueSchoolLink from './components/VueSchoolLink.vue'
+// import VueJobs from './components/VueJobs.vue'
 
 export default Object.assign({}, VPTheme, {
   Layout: () => {
     // @ts-ignore
     return h(VPTheme.Layout, null, {
-      banner: () => h(Banner),
       'sidebar-top': () => h(PreferenceSwitch),
       'aside-mid': () => h(SponsorsAside),
-      'aside-bottom': () => h(VueJobs)
+      // 'aside-bottom': () => h(VueJobs)
     })
   },
   enhanceApp({ app }: { app: App }) {
     app.provide('prefer-composition', preferComposition)
     app.provide('prefer-sfc', preferSFC)
     app.provide('filter-headers', filterHeadersByPreference)
-    app.component('VueSchoolLink', VueSchoolLink)
+    // app.component('VueSchoolLink', VueSchoolLink)
   }
 })

--- a/ko-KR/.vitepress/theme/styles/badges.css
+++ b/ko-KR/.vitepress/theme/styles/badges.css
@@ -1,5 +1,5 @@
 .vt-badge.wip:before {
-  content: 'WIP';
+  content: '작업 중...';
 }
 
 .vt-badge.ts {
@@ -16,11 +16,11 @@
 }
 
 .vt-badge.dev-only:before {
-  content: 'Dev only';
+  content: '개발용';
 }
 
 .vt-badge.experimental:before {
-  content: 'Experimental';
+  content: '실험적';
 }
 
 .vt-badge[data-text]:before {

--- a/ko-KR/pnpm-lock.yaml
+++ b/ko-KR/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@types/markdown-it': ^12.2.3
@@ -137,10 +137,25 @@ packages:
       '@algolia/requester-common': 4.10.5
     dev: false
 
+  /@babel/helper-validator-identifier/7.16.7:
+    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
+    engines: {node: '>=6.9.0'}
+    dev: false
+
   /@babel/parser/7.16.4:
     resolution: {integrity: sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.18.4
+    dev: false
+
+  /@babel/types/7.18.4:
+    resolution: {integrity: sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      to-fast-properties: 2.0.0
     dev: false
 
   /@docsearch/css/3.0.0-alpha.41:
@@ -720,6 +735,11 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+    dev: false
+
+  /to-fast-properties/2.0.0:
+    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
+    engines: {node: '>=4'}
     dev: false
 
   /vite/2.8.1:

--- a/ko-KR/src/translations/index.md
+++ b/ko-KR/src/translations/index.md
@@ -2,17 +2,13 @@
 aside: false
 ---
 
-# Translations <sup class="vt-badge wip" />
+# 번역 <sup class="vt-badge wip" />
 
-The Vue documentation has recently undergone a major revision, so there are no completed translations in other languages yet.
+Vue 문서는 최근에 주요 개정을 거쳐 아직 한국어 번역이 완성되지 않았습니다.
 
-Translation efforts are managed in the [vuejs-translations](https://github.com/vuejs-translations/) GitHub organization. There are currently the following translations underway. If you want to contribute, you can open an issue to express your interest.
+번역 작업은 [vuejs-kr/docs-next](https://github.com/vuejs-kr/docs-next)에서 관리됩니다.
+기여하고 싶다면 슬랙의 워크스페이스 [Vue.js Korea](vuejs-korea.slack.com)에 참여하여 관심을 표할 수 있습니다.
 
-- [Simplified Chinese](https://github.com/vuejs-translations/docs-zh-cn)
-- [Japanese](https://github.com/vuejs-translations/docs-ja)
+## 번역에 기여하기 전에
 
-## Starting a new Translation
-
-We are hoping to establish a standard workflow for community translations so that we can more easily coordinate community efforts. Please keep an eye on the [Translation Guidelines repo](https://github.com/vuejs-translations/guidelines/blob/main/README.md) for updates.
-
-In the meanwhile, if you are interested in starting translation for a new language, please open a thread in the [Discussions](https://github.com/vuejs-translations/guidelines/discussions) (and check if there is already one created for your language). This can help you find fellow collaborators and avoid duplicated efforts.
+번역 기여를 시작하기 전에 작업에 효율과 통일성을 위해 [번역 가이드](https://github.com/vuejs-kr/docs-next/wiki) 문서를 확인하십시오.


### PR DESCRIPTION
1. gitignore 리스트 추가
2. 레이아웃 다듬기
    - 최상단 초록바 삭제
    - 상단 네비 - 번역 불필요 페이지 내부 링크 → 공식 페이지 외부 링크
    - 상단 네비 - 불필요한 중복 링크  (스폰서, 파트너) → 생태계 탭 내부로 통합
    - 상단 네비 - 스타일가이드 링크 임시 히든처리
    - 문서 내 우측 사이드 바 - 광고박스 히든처리
    - 문서 내 우측 사이드 바 - 구인박스 히든처리
    - 문서 하단 - 깃허브에서 이 페이지 편집(한국어 작업 레파지토리로 변경)
3. 번역 가이드 페이지 임시 수정