### PR TITLE
/src/guide/reusability

### DIFF
--- a/ko-KR/.vitepress/config.ts
+++ b/ko-KR/.vitepress/config.ts
@@ -207,11 +207,11 @@ export const sidebar = {
       text: '재사용성',
       items: [
         {
-          text: '조합하기',
+          text: '구성화',
           link: '/guide/reusability/composables'
         },
         {
-          text: '커스텀 디렉티브(Custom Directives)',
+          text: '커스텀 지시문',
           link: '/guide/reusability/custom-directives'
         },
         { text: '플러그인', link: '/guide/reusability/plugins' }

--- a/ko-KR/src/guide/reusability/composables.md
+++ b/ko-KR/src/guide/reusability/composables.md
@@ -1,7 +1,4 @@
-:::warning 현재 이 문서는 번역 작업이 진행중입니다
-:::
-
-# Composables
+# 구성화
 
 <script setup>
 import { useMouse } from './mouse'
@@ -9,20 +6,42 @@ const { x, y } = useMouse()
 </script>
 
 :::tip
-This section assumes basic knowledge of Composition API. If you have been learning Vue with Options API only, you can set the API Preference to Composition API (using the toggle at the top of the left sidebar) and re-read the [Reactivity Fundamentals](/guide/essentials/reactivity-fundamentals.html) and [Lifecycle Hooks](/guide/essentials/lifecycle.html) chapters.
+이 섹션에서는 `컴포지션 API`에 대한 기본 지식이 있다고 가정합니다.
+`옵션 API`만 배웠다면 왼쪽 사이드바 상단의 `API 스타일 설정`을 `컴포지션 API`로 설정하고 [반응형 기초](/guide/essentials/reactivity-fundamentals.html) 및 [수명주기 훅](/guide/essentials/lifecycle.html) 장을 다시 읽을 수 있습니다.
 :::
 
-## What is a "Composable"?
+:::info 번역자 주석: 이 문서를 읽기 전에
+우리는 운전면허를 취득한지 얼마 되지 않았고, 자동차 주차를 하다가 전봇대에 가볍게 접촉해 범퍼가 파손되었다고 가정해봅시다.
+이 때, 범퍼는 "차"를 구성하고 있는 수많은 "구성품" 중에 하나이므로 우리는 새 차를 사지않고 범퍼만 교체합니다.
+차와 범퍼가 일체화 되어있다면, 우리는 차를 새로 구매하거나, 파손된 채로 타거나, 무언가를 범퍼에 붙여 지저분하게 타야했을 것입니다.
 
-In the context of Vue applications, a "composable" is a function that leverages Vue Composition API to encapsulate and reuse **stateful logic**.
+생각만해도 머리가 아파옵니다.
+개발도 이와 마찬가지로, 어떠한 작은 기능들을 각각 하나의 "구성품"으로 만들고, 이러한 구성품들의 조합으로 앱이 완성됩니다.
+그러나 수많은 구성품들을 쉽게 가져다 쓰면서도 가독성이 좋은 코드를 작성하는 건 매우 힘든 일입니다.
+Vue는 이러한 개발 패턴을 쉽게 적용할 수 있게 많은 고민을 한 프레임워크라고 생각됩니다.
 
-When building frontend applications, we often have the need to reuse logic for common tasks. For example, we may need to format dates in many places, so we extract a reusable function for that. This formatter function encapsulates **stateless logic**: it takes some input and immediately returns expected output. There are many libraries out there for reusing stateless logic - for example [lodash](https://lodash.com/) and [date-fns](https://date-fns.org/), which you may have heard of.
+이 문서의 키워드인 "Composable"을 직역하면 "구성 가능한"입니다.
+그러나 좀 더 매끄러운 의미 전달을 위해 Composable은 "구성화(부품화)"라고 표기하였습니다.
+:::
 
-In comparison, stateful logic involves managing state that changes over time. A simple example would be tracking the current position of the mouse on a page. In real world scenarios, it could also be more complex logic such as touch gestures or connection status to a database.
+## "구성화"란?
 
-## Mouse Tracker Example
+Vue 앱의 컨텍스트에서 "구성화"는 Vue 컴포지션 API를 활용하여 **상태 저장 로직**를 캡슐화하고 재사용하는 기능입니다.
 
-If we were to implement the mouse tracking functionality using Composition API directly inside a component, it would look like this:
+프론트엔드 앱을 구축할 때, 여러 곳에서 효율적으로 같은 작업을 하기 위해 로직을 재사용해야 하는 경우가 종종 있습니다.
+예를 들어 여러 위치에서 날짜 형식을 지정해야 할 수 있고, 이를 위해 재사용 가능한 함수를 생성합니다.
+이 함수는 상태 비저장 로직을 캡슐화합니다.
+일부 입력을 받고 즉시 계산된 값을 반환합니다.
+상태 비저장 로직을 재사용하기 위한 많은 라이브러리가 있습니다.
+예를 들어 [lodash](https://lodash.com/)나 [date-fns](https://date-fns.org/)는 들어본 적이 있을 것입니다.
+
+이에 비해 상태 저장 로직은 시간이 지남에 따라 변경되는 상태 관리가 포함됩니다.
+간단한 예는 페이지에서 마우스의 현재 위치를 추적하는 것입니다.
+실제 시나리오에서는 터치 제스처 또는 데이터베이스 연결 상태와 같은 더 복잡한 로직이 될 수도 있습니다.
+
+## 마우스 위치 추적기 예제
+
+컴포넌트 내에서 직접 컴포지션 API를 사용하여 마우스 추적 기능은 다음과 같이 구현할 수 있습니다:
 
 ```vue
 <script setup>
@@ -40,38 +59,39 @@ onMounted(() => window.addEventListener('mousemove', update))
 onUnmounted(() => window.removeEventListener('mousemove', update))
 </script>
 
-<template>Mouse position is at: {{ x }}, {{ y }}</template>
+<template>마우스 위치: {{ x }}, {{ y }}</template>
 ```
 
-But what if we want to reuse the same logic in multiple components? We can extract the logic into an external file, as a composable function:
+그러나 여러 컴포넌트에서 동일한 로직을 재사용하려면 어떻게 해야 할까요?
+로직을 구성화한 함수로 재구성 후 외부 파일로 추출할 수 있습니다:
 
 ```js
 // mouse.js
 import { ref, onMounted, onUnmounted } from 'vue'
 
-// by convention, composable function names start with "use"
+// 관례상, 구성화한 함수 이름은 "use"로 시작합니다.
 export function useMouse() {
-  // state encapsulated and managed by the composable
+  // 구성화로 캡슐화된 내부에서 관리되는 상태
   const x = ref(0)
   const y = ref(0)
 
-  // a composable can update its managed state over time.
+  // 구성화는 시간이 지남에 따라 관리되는 상태를 업데이트할 수 있습니다.
   function update(event) {
     x.value = event.pageX
     y.value = event.pageY
   }
 
-  // a composable can also hook into its owner component's
-  // lifecycle to setup and teardown side effects.
+  // 구성화는 또한 이것을 사용하는 컴포넌트의 수명주기에 연결되어
+  // 사이드 이펙트를 설정 및 해제할 수 있습니다.
   onMounted(() => window.addEventListener('mousemove', update))
   onUnmounted(() => window.removeEventListener('mousemove', update))
 
-  // expose managed state as return value
+  // 관리 상태를 반환 값으로 노출
   return { x, y }
 }
 ```
 
-And this is how it can be used in components:
+그리고 이것이 컴포넌트에서 사용되는 방법입니다:
 
 ```vue
 <script setup>
@@ -80,34 +100,39 @@ import { useMouse } from './mouse.js'
 const { x, y } = useMouse()
 </script>
 
-<template>Mouse position is at: {{ x }}, {{ y }}</template>
+<template>마우스 위치: {{ x }}, {{ y }}</template>
 ```
 
 <div class="demo">
-  Mouse position is at: {{ x }}, {{ y }}
+  마우스 위치: {{ x }}, {{ y }}
 </div>
 
-[Try it in the Playground](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHVzZU1vdXNlIH0gZnJvbSAnLi9tb3VzZS5qcydcblxuY29uc3QgeyB4LCB5IH0gPSB1c2VNb3VzZSgpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICBNb3VzZSBwb3NpdGlvbiBpcyBhdDoge3sgeCB9fSwge3sgeSB9fVxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59IiwibW91c2UuanMiOiJpbXBvcnQgeyByZWYsIG9uTW91bnRlZCwgb25Vbm1vdW50ZWQgfSBmcm9tICd2dWUnXG5cbmV4cG9ydCBmdW5jdGlvbiB1c2VNb3VzZSgpIHtcbiAgY29uc3QgeCA9IHJlZigwKVxuICBjb25zdCB5ID0gcmVmKDApXG5cbiAgZnVuY3Rpb24gdXBkYXRlKGV2ZW50KSB7XG4gICAgeC52YWx1ZSA9IGV2ZW50LnBhZ2VYXG4gICAgeS52YWx1ZSA9IGV2ZW50LnBhZ2VZXG4gIH1cblxuICBvbk1vdW50ZWQoKCkgPT4gd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ21vdXNlbW92ZScsIHVwZGF0ZSkpXG4gIG9uVW5tb3VudGVkKCgpID0+IHdpbmRvdy5yZW1vdmVFdmVudExpc3RlbmVyKCdtb3VzZW1vdmUnLCB1cGRhdGUpKVxuXG4gIHJldHVybiB7IHgsIHkgfVxufSJ9)
+[온라인 연습장으로 실행하기](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHVzZU1vdXNlIH0gZnJvbSAnLi9tb3VzZS5qcydcblxuY29uc3QgeyB4LCB5IH0gPSB1c2VNb3VzZSgpXG48L3NjcmlwdD5cblxuPHRlbXBsYXRlPlxuICDrp4jsmrDsiqQg7JyE7LmYOiB7eyB4IH19LCB7eyB5IH19XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwidnVlL3NlcnZlci1yZW5kZXJlclwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy9zZXJ2ZXItcmVuZGVyZXIuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59IiwibW91c2UuanMiOiJpbXBvcnQgeyByZWYsIG9uTW91bnRlZCwgb25Vbm1vdW50ZWQgfSBmcm9tICd2dWUnXG5cbmV4cG9ydCBmdW5jdGlvbiB1c2VNb3VzZSgpIHtcbiAgY29uc3QgeCA9IHJlZigwKVxuICBjb25zdCB5ID0gcmVmKDApXG5cbiAgZnVuY3Rpb24gdXBkYXRlKGV2ZW50KSB7XG4gICAgeC52YWx1ZSA9IGV2ZW50LnBhZ2VYXG4gICAgeS52YWx1ZSA9IGV2ZW50LnBhZ2VZXG4gIH1cblxuICBvbk1vdW50ZWQoKCkgPT4gd2luZG93LmFkZEV2ZW50TGlzdGVuZXIoJ21vdXNlbW92ZScsIHVwZGF0ZSkpXG4gIG9uVW5tb3VudGVkKCgpID0+IHdpbmRvdy5yZW1vdmVFdmVudExpc3RlbmVyKCdtb3VzZW1vdmUnLCB1cGRhdGUpKVxuXG4gIHJldHVybiB7IHgsIHkgfVxufSJ9)
 
-As we can see, the core logic remains exactly the same - all we had to do was move it into an external function and return the state that should be exposed. Same as inside a component, you can use the full range of [Composition API functions](/api/#composition-api) in composables. The same `useMouse()` functionality can now be used in any component.
+보다시피, 핵심 로직은 정확히 동일합니다.
+조치한 것은 그것을 외부 함수로 옮기고, 노출되어야 하는 상태를 반환하는 것뿐이었습니다.
+컴포넌트 내부처럼 구성화에서는 [컴포지션 API 함수](/api/#composition-api)의 전체를 사용할 수 있습니다.
+`useMouse()` 함수는 이제 모든 컴포넌트에서 사용할 수 있습니다.
 
-The cooler part about composables though, is that you can also nest them: one composable function can call one or more other composable functions. This enables us to compose complex logic using small, isolated units, similar to how we compose an entire application using components. In fact, this is why we decided to call the collection of APIs that make this pattern possible Composition API.
+하지만 구성화의 멋진 부분은 중첩할 수도 있다는 것입니다.
+하나의 구성화 함수는 하나 이상의 "다른 구성화 함수"를 호출할 수 있습니다.
+이를 통해 컴포넌트를 사용하여 전체 앱을 구성하는 방법과 유사하게 작게 독립된 단위를 사용하여 복잡한 로직을 구성할 수 있습니다.
+사실 이 패턴을 가능하게 하는 API 모음을 "**컴포지션 API**"라고 부르기로 결정한 이유입니다.
 
-As an example, we can extract the logic of adding and cleaning up a DOM event listener into its own composable:
+<div id='use-event-listener'></div>
+예를 들어 DOM 이벤트 리스너를 자체 구성화에 추가하고 정리하는 로직을 추출할 수 있습니다:
 
 ```js
 // event.js
 import { onMounted, onUnmounted } from 'vue'
 
 export function useEventListener(target, event, callback) {
-  // if you want, you can also make this
-  // support selector strings as target
   onMounted(() => target.addEventListener(event, callback))
   onUnmounted(() => target.removeEventListener(event, callback))
 }
 ```
 
-And now our `useMouse()` can be simplified to:
+이제 `useMouse()`를 다음과 같이 단순화할 수 있습니다:
 
 ```js{3,9-12}
 // mouse.js
@@ -128,12 +153,16 @@ export function useMouse() {
 ```
 
 :::tip
-Each component instance calling `useMouse()` will create its own copies of `x` and `y` state so they won't interfere with one another. If you want to manage shared state between components, read the [State Management](/guide/scaling-up/state-management.html) chapter.
+`useMouse()`를 호출하는 각 컴포넌트 인스턴스는 서로 간섭하지 않도록 `x`와 `y` 상태의 자체 복사본을 생성합니다.
+컴포넌트 간의 공유 상태를 관리하려면 [상태 관리하기](/guide/scaling-up/state-management.html) 장을 읽으십시오.
+
+[comment]: <> (/guide/scaling-up/state-management.md 번역 후 링크 수정 필요)
 :::
 
-## Async State Example
+## 비동기 상태 예제
 
-The `useMouse()` composable doesn't take any arguments, so let's take a look at another example that makes use of one. When doing async data fetching, we often need to handle different states: loading, success, and error:
+구성화 함수 `useMouse()`는 인자를 사용하지 않으므로, 인자를 사용하는 다른 예를 살펴보겠습니다.
+비동기 데이터 가져오기를 수행할 때 로드, 성공 및 애러와 같은 다양한 상태를 처리해야 하는 경우가 많습니다:
 
 ```vue
 <script setup>
@@ -149,16 +178,17 @@ fetch('...')
 </script>
 
 <template>
-  <div v-if="error">Oops! Error encountered: {{ error.message }}</div>
+  <div v-if="error">앗! 오류 발생: {{ error.message }}</div>
   <div v-else-if="data">
-    Data loaded:
+    로드된 데이터:
     <pre>{{ data }}</pre>
   </div>
-  <div v-else>Loading...</div>
+  <div v-else>로딩...</div>
 </template>
 ```
 
-Again, it would be tedious to have to repeat this pattern in every component that needs to fetch data. Let's extract it into a composable:
+다시 말하지만 데이터를 가져와야 하는 모든 컴포넌트에서 이 패턴을 반복해야 한다면 끔직할 것입니다.
+추출해서 구성화해 보겠습니다:
 
 ```js
 // fetch.js
@@ -177,7 +207,7 @@ export function useFetch(url) {
 }
 ```
 
-Now in our component we can just do:
+이제 컴포넌트에서 다음을 수행할 수 있습니다:
 
 ```vue
 <script setup>
@@ -187,7 +217,9 @@ const { data, error } = useFetch('...')
 </script>
 ```
 
-`useFetch()` takes a static URL string as input - so it performs the fetch only once and is then done. What if we want it to re-fetch whenever the URL changes? We can achieve that by also accepting refs as an argument:
+`useFetch()`는 정적 URL 문자열을 입력으로 사용하므로 가져오기를 한 번만 수행한 다음 완료됩니다.
+URL이 변경될 때마다 다시 가져오기를 원하면 어떻게 해야 할까요?
+ref를 인자로 사용 가능토록 구현하면 됩니다:
 
 ```js
 // fetch.js
@@ -198,10 +230,10 @@ export function useFetch(url) {
   const error = ref(null)
 
   function doFetch() {
-    // reset state before fetching..
+    // 가져오기 전에 상태 재설정..
     data.value = null
     error.value = null
-    // unref() unwraps potential refs
+    // unref()는 ref의 래핑을 해제합니다.
     fetch(unref(url))
       .then((res) => res.json())
       .then((json) => (data.value = json))
@@ -209,11 +241,11 @@ export function useFetch(url) {
   }
 
   if (isRef(url)) {
-    // setup reactive re-fetch if input URL is a ref
+    // 설정하기: 입력 URL이 ref인 경우 반응적 다시 가져오기
     watchEffect(doFetch)
   } else {
-    // otherwise, just fetch once
-    // and avoid the overhead of a watcher
+    // 그렇지 않으면 한 번만 가져 와서
+    // 관찰자의 오버 헤드를 피하합니다.
     doFetch()
   }
 
@@ -221,80 +253,98 @@ export function useFetch(url) {
 }
 ```
 
-This version of `useFetch()` now accepts both static URL strings and refs of URL strings. When it detects that the URL is a dynamic ref using [`isRef()`](/api/reactivity-utilities.html#isref), it sets up a reactive effect using [`watchEffect()`](/api/reactivity-core.html#watcheffect). The effect will run immediately, and tracking the URL ref as a dependency in the process. Whenever the URL ref changes, the data will be reset and fetched again.
+이 버전의 `useFetch()`는 이제 정적 URL 문자열과 ref된 URL 문자열 모두 허용합니다.
+URL이 [`isRef()`](/api/reactivity-utilities.html#isref)를 사용하여 동적 참조임을 감지하면,
+[`watchEffect()`](/api/reactivity-core.html#watcheffect)를 사용하여 반응형 이팩트를 설정합니다.
+이팩트는 즉시 실행되고 프로세스의 종속성으로 URL ref를 관찰합니다.
+URL ref가 변경될 때마다 데이터가 재설정되고 다시 가져옵니다.
 
-Here's [the updated version of `useFetch()`](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiwgY29tcHV0ZWQgfSBmcm9tICd2dWUnXG5pbXBvcnQgeyB1c2VGZXRjaCB9IGZyb20gJy4vdXNlRmV0Y2guanMnXG5cbmNvbnN0IGJhc2VVcmwgPSAnaHR0cHM6Ly9qc29ucGxhY2Vob2xkZXIudHlwaWNvZGUuY29tL3RvZG9zLydcbmNvbnN0IGlkID0gcmVmKCcxJylcbmNvbnN0IHVybCA9IGNvbXB1dGVkKCgpID0+IGJhc2VVcmwgKyBpZC52YWx1ZSlcblxuY29uc3QgeyBkYXRhLCBlcnJvciwgcmV0cnkgfSA9IHVzZUZldGNoKHVybClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIExvYWQgcG9zdCBpZDpcbiAgPGJ1dHRvbiB2LWZvcj1cImkgaW4gNVwiIEBjbGljaz1cImlkID0gaVwiPnt7IGkgfX08L2J1dHRvbj5cblxuXHQ8ZGl2IHYtaWY9XCJlcnJvclwiPlxuICAgIDxwPk9vcHMhIEVycm9yIGVuY291bnRlcmVkOiB7eyBlcnJvci5tZXNzYWdlIH19PC9wPlxuICAgIDxidXR0b24gQGNsaWNrPVwicmV0cnlcIj5SZXRyeTwvYnV0dG9uPlxuICA8L2Rpdj5cbiAgPGRpdiB2LWVsc2UtaWY9XCJkYXRhXCI+RGF0YSBsb2FkZWQ6IDxwcmU+e3sgZGF0YSB9fTwvcHJlPjwvZGl2PlxuICA8ZGl2IHYtZWxzZT5Mb2FkaW5nLi4uPC9kaXY+XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiXG4gIH1cbn0iLCJ1c2VGZXRjaC5qcyI6ImltcG9ydCB7IHJlZiwgaXNSZWYsIHVucmVmLCB3YXRjaEVmZmVjdCB9IGZyb20gJ3Z1ZSdcblxuZXhwb3J0IGZ1bmN0aW9uIHVzZUZldGNoKHVybCkge1xuICBjb25zdCBkYXRhID0gcmVmKG51bGwpXG4gIGNvbnN0IGVycm9yID0gcmVmKG51bGwpXG5cbiAgYXN5bmMgZnVuY3Rpb24gZG9GZXRjaCgpIHtcbiAgICAvLyByZXNldCBzdGF0ZSBiZWZvcmUgZmV0Y2hpbmcuLlxuICAgIGRhdGEudmFsdWUgPSBudWxsXG4gICAgZXJyb3IudmFsdWUgPSBudWxsXG4gICAgXG4gICAgLy8gcmVzb2x2ZSB0aGUgdXJsIHZhbHVlIHN5bmNocm9ub3VzbHkgc28gaXQncyB0cmFja2VkIGFzIGFcbiAgICAvLyBkZXBlbmRlbmN5IGJ5IHdhdGNoRWZmZWN0KClcbiAgICBjb25zdCB1cmxWYWx1ZSA9IHVucmVmKHVybClcbiAgICBcbiAgICB0cnkge1xuICAgICAgLy8gYXJ0aWZpY2lhbCBkZWxheSAvIHJhbmRvbSBlcnJvclxuICBcdCAgYXdhaXQgdGltZW91dCgpXG4gIFx0ICAvLyB1bnJlZigpIHdpbGwgcmV0dXJuIHRoZSByZWYgdmFsdWUgaWYgaXQncyBhIHJlZlxuXHQgICAgLy8gb3RoZXJ3aXNlIHRoZSB2YWx1ZSB3aWxsIGJlIHJldHVybmVkIGFzLWlzXG4gICAgXHRjb25zdCByZXMgPSBhd2FpdCBmZXRjaCh1cmxWYWx1ZSlcblx0ICAgIGRhdGEudmFsdWUgPSBhd2FpdCByZXMuanNvbigpXG4gICAgfSBjYXRjaCAoZSkge1xuICAgICAgZXJyb3IudmFsdWUgPSBlXG4gICAgfVxuICB9XG5cbiAgaWYgKGlzUmVmKHVybCkpIHtcbiAgICAvLyBzZXR1cCByZWFjdGl2ZSByZS1mZXRjaCBpZiBpbnB1dCBVUkwgaXMgYSByZWZcbiAgICB3YXRjaEVmZmVjdChkb0ZldGNoKVxuICB9IGVsc2Uge1xuICAgIC8vIG90aGVyd2lzZSwganVzdCBmZXRjaCBvbmNlXG4gICAgZG9GZXRjaCgpXG4gIH1cblxuICByZXR1cm4geyBkYXRhLCBlcnJvciwgcmV0cnk6IGRvRmV0Y2ggfVxufVxuXG4vLyBhcnRpZmljaWFsIGRlbGF5XG5mdW5jdGlvbiB0aW1lb3V0KCkge1xuICByZXR1cm4gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgIHNldFRpbWVvdXQoKCkgPT4ge1xuICAgICAgaWYgKE1hdGgucmFuZG9tKCkgPiAwLjMpIHtcbiAgICAgICAgcmVzb2x2ZSgpXG4gICAgICB9IGVsc2Uge1xuICAgICAgICByZWplY3QobmV3IEVycm9yKCdSYW5kb20gRXJyb3InKSlcbiAgICAgIH1cbiAgICB9LCAzMDApXG4gIH0pXG59In0=), with an artificial delay and randomized error for demo purposes.
+여기 [`useFetch()`의 업데이트된 버전](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiwgY29tcHV0ZWQgfSBmcm9tICd2dWUnXG5pbXBvcnQgeyB1c2VGZXRjaCB9IGZyb20gJy4vdXNlRmV0Y2guanMnXG5cbmNvbnN0IGJhc2VVcmwgPSAnaHR0cHM6Ly9qc29ucGxhY2Vob2xkZXIudHlwaWNvZGUuY29tL3RvZG9zLydcbmNvbnN0IGlkID0gcmVmKCcxJylcbmNvbnN0IHVybCA9IGNvbXB1dGVkKCgpID0+IGJhc2VVcmwgKyBpZC52YWx1ZSlcblxuY29uc3QgeyBkYXRhLCBlcnJvciwgcmV0cnkgfSA9IHVzZUZldGNoKHVybClcbjwvc2NyaXB0PlxuXG48dGVtcGxhdGU+XG4gIExvYWQgcG9zdCBpZDpcbiAgPGJ1dHRvbiB2LWZvcj1cImkgaW4gNVwiIEBjbGljaz1cImlkID0gaVwiPnt7IGkgfX08L2J1dHRvbj5cblxuXHQ8ZGl2IHYtaWY9XCJlcnJvclwiPlxuICAgIDxwPuyVlyEg7Jik66WYIOuwnOyDnToge3sgZXJyb3IubWVzc2FnZSB9fTwvcD5cbiAgICA8YnV0dG9uIEBjbGljaz1cInJldHJ5XCI+7J6s7Iuc64+EPC9idXR0b24+XG4gIDwvZGl2PlxuICA8ZGl2IHYtZWxzZS1pZj1cImRhdGFcIj7roZzrk5zrkJwg642w7J207YSwOiA8cHJlPnt7IGRhdGEgfX08L3ByZT48L2Rpdj5cbiAgPGRpdiB2LWVsc2U+66Gc65SpLi4uPC9kaXY+XG48L3RlbXBsYXRlPiIsImltcG9ydC1tYXAuanNvbiI6IntcbiAgXCJpbXBvcnRzXCI6IHtcbiAgICBcInZ1ZVwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy92dWUucnVudGltZS5lc20tYnJvd3Nlci5qc1wiLFxuICAgIFwidnVlL3NlcnZlci1yZW5kZXJlclwiOiBcImh0dHBzOi8vc2ZjLnZ1ZWpzLm9yZy9zZXJ2ZXItcmVuZGVyZXIuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59IiwidXNlRmV0Y2guanMiOiJpbXBvcnQgeyByZWYsIGlzUmVmLCB1bnJlZiwgd2F0Y2hFZmZlY3QgfSBmcm9tICd2dWUnXG5cbmV4cG9ydCBmdW5jdGlvbiB1c2VGZXRjaCh1cmwpIHtcbiAgY29uc3QgZGF0YSA9IHJlZihudWxsKVxuICBjb25zdCBlcnJvciA9IHJlZihudWxsKVxuXG4gIGFzeW5jIGZ1bmN0aW9uIGRvRmV0Y2goKSB7XG4gICAgLy8g6rCA7KC47Jik6riwIOyghOyXkCDsg4Htg5wg7J6s7ISk7KCVLi5cbiAgICBkYXRhLnZhbHVlID0gbnVsbFxuICAgIGVycm9yLnZhbHVlID0gbnVsbFxuICAgIFxuICAgIC8vIHdhdGNoRWZmZWN0KCnsl5Ag7J2Y7ZW0IOyiheyGjeyEseycvOuhnCDstpTsoIHrkJjrj4TroZ1cbiAgICAvLyBVUkwg6rCS7J2EIOuPmeq4sOyLneycvOuhnCByZXNvbHZl7ZWp64uI64ukLlxuICAgIGNvbnN0IHVybFZhbHVlID0gdW5yZWYodXJsKVxuICAgIFxuICAgIHRyeSB7XG4gICAgICAvLyDsnbjsnITsoIHsnbgg65Sc66CI7J20IC8g66y07J6R7JyEIOyVoOufrFxuICBcdCAgYXdhaXQgdGltZW91dCgpXG4gIFx0ICAvLyB1bnJlZigp64qUIHJlZuydtOuptCByZWYg6rCS7J2EIOuwmO2ZmO2VqeuLiOuLpC5cbiAgICAgIC8vIOq3uOugh+yngCDslYrsnLzrqbQg6rCS7J2EIOyeiOuKlCDqt7jrjIDroZwg67CY7ZmY7ZWp64uI64ukLlxuICAgIFx0Y29uc3QgcmVzID0gYXdhaXQgZmV0Y2godXJsVmFsdWUpXG5cdCAgICBkYXRhLnZhbHVlID0gYXdhaXQgcmVzLmpzb24oKVxuICAgIH0gY2F0Y2ggKGUpIHtcbiAgICAgIGVycm9yLnZhbHVlID0gZVxuICAgIH1cbiAgfVxuXG4gIGlmIChpc1JlZih1cmwpKSB7XG4gICAgLy8g7ISk7KCV7ZWY6riwOiDsnoXroKUgVVJM7J20IHJlZuyduCDqsr3smrAg67CY7J2R7KCBIOuLpOyLnCDqsIDsoLjsmKTquLBcbiAgICB3YXRjaEVmZmVjdChkb0ZldGNoKVxuICB9IGVsc2Uge1xuICAgIC8vIOq3uOugh+yngCDslYrsnLzrqbQg7ZWcIOuyiOunjCDqsIDsoLjsmKTquLBcbiAgICBkb0ZldGNoKClcbiAgfVxuXG4gIHJldHVybiB7IGRhdGEsIGVycm9yLCByZXRyeTogZG9GZXRjaCB9XG59XG5cbi8vIOyduOychOyggeyduCDrlJzroIjsnbRcbmZ1bmN0aW9uIHRpbWVvdXQoKSB7XG4gIHJldHVybiBuZXcgUHJvbWlzZSgocmVzb2x2ZSwgcmVqZWN0KSA9PiB7XG4gICAgc2V0VGltZW91dCgoKSA9PiB7XG4gICAgICBpZiAoTWF0aC5yYW5kb20oKSA+IDAuMykge1xuICAgICAgICByZXNvbHZlKClcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIHJlamVjdChuZXcgRXJyb3IoJ+ustOyekeychCDslaDrn6wnKSlcbiAgICAgIH1cbiAgICB9LCAzMDApXG4gIH0pXG59In0=)이 있습니다.
+데모용이므로 인위적인 지연과 무작위 애러가 있습니다.
 
-## Conventions and Best Practices
+## 관례와 모범 사례
 
-### Naming
+### 작명
 
-It is a convention to name composable functions with camelCase names that start with "use".
+"use"로 시작하는 camelCase 이름으로 구성화 함수의 이름을 지정하는 것이 관례입니다.
 
-### Input Arguments
+### 입력 인자
 
-A composable can accept ref arguments even if it doesn't rely on it for reactivity. If you are writing a composable that may be used by other developers, it's a good idea to handle the case of input arguments being refs instead of raw values. The [`unref()`](/api/reactivity-utilities.html#unref) utility function will come in handy for this purpose:
+구성화 함수는 반응형에 의존하지 않더라도 ref 인자를 받을 수 있습니다.
+다른 개발자가 사용할 수 있는 구성화 함수를 작성하는 경우, 입력 인자가 원시 값 대신 ref인 경우를 처리하는 것이 좋습니다.
+[`unref()`](/api/reactivity-utilities.html#unref) 유틸리티 함수는 이러한 목적의 구현에 유용할 것입니다:
 
 ```js
 import { unref } from 'vue'
 
 function useFeature(maybeRef) {
-  // if maybeRef is indeed a ref, its .value will be returned
-  // otherwise, maybeRef is returned as-is
+  // 만약 mayRef가 실제로 ref라면,
+  // mayRef.value가 반환될 것이고,
+  // 그렇지 않을 경우, mayRef는 있는 그대로 반환될 것입니다.
   const value = unref(maybeRef)
 }
 ```
 
-If your composable creates reactive effects when the input is a ref, make sure to either explicitly watch the ref with `watch()`, or call `unref()` inside a `watchEffect()` so that it is properly tracked.
+입력이 ref일 때 구성화가 반응 효과를 생성하는 경우, `watch()`를 사용하여 ref를 명시적으로 관찰하거나, `watchEffect()` 내부에서 `unref()`를 호출하여 올바르게 추적되도록 하십시오.
 
-### Return Values
+### 반환 값
 
-You have probably noticed that we have been exclusively using `ref()` instead of `reactive()` in composables. The recommended convention is to always return an object of refs from composables, so that it can be destructured in components while retaining reactivity:
+구성화에서 `reactive()` 대신 `ref()`를 독점적으로 사용하고 있다는 것을 눈치챘을 것입니다.
+컴포넌트에서 항상 ref 객체를 반환하여 반응성을 유지하면서 컴포넌트에서 구조화할 수 있도록 하는 것이 좋습니다.
 
 ```js
-// x and y are refs
+// x와 y는 ref
 const { x, y } = useMouse()
 ```
 
-Returning a reactive object from a composable will cause such destructures to lose the reactivity connection to the state inside the composable, while the refs will retain that connection.
+구성화 함수에서 reactive 객체를 반환하는 경우, 위 코드처럼 분해 할당 문법을 사용하면 구성화 함수 내부 상태에 대한 반응성 연결이 끊어지지만, 분해 할당 문법을 사용하지 않는 경우에는 ref 연결상태가 유지됩니다.
 
-If you prefer to use returned state from composables as object properties, you can wrap the returned object with `reactive()` so that the refs are unwrapped. For example:
+구성화 함수로 반환된 ref 상태를 감싸는 객체를 `.value` 접두사 없이 객체 속성처럼 사용하고 싶다면, 반환된 일반 객체를 `reactive()`로 래핑하여 ref가 래핑되지 않도록 할 수 있습니다:
 
 ```js
 const mouse = reactive(useMouse())
-// mouse.x is linked to original ref
+// mouse.x는 원본 ref에 연결되어 있습니다.
 console.log(mouse.x)
 ```
 
 ```vue-html
-Mouse position is at: {{ mouse.x }}, {{ mouse.y }}
+마우스 위치: {{ mouse.x }}, {{ mouse.y }}
 ```
 
-### Side Effects
+### 사이드 이펙트
 
-It is OK to perform side effects (e.g. adding DOM event listeners or fetching data) in composables, but pay attention to the following rules:
+구성화에서 사이드 에픽트(예: DOM 이벤트 리스너 추가 또는 데이터 가져오기)를 수행하는 것은 괜찮지만 다음 규칙에 주의하십시오:
 
-- If you are working on an application that utilizes [Server-Side Rendering](/guide/scaling-up/ssr.html) (SSR), make sure to perform DOM-specific side effects in post-mount lifecycle hooks, e.g. `onMounted()`. These hooks are only called in the browser, so you can ensure code inside it has access to the DOM.
+- [서버 사이드 렌더링](/guide/scaling-up/ssr.html)(SSR)을 사용하는 앱에서 작업하는 경우,
+  마운트 후 수명주기 훅인 `onMounted()`에서 DOM 관련 사이드 이펙트를 수행해야 합니다.
+  이 훅은 브라우저에서만 호출되므로 내부 코드가 DOM에 접근할 수 있는지 알 수 있습니다.
 
-- Make sure to clean up side effects in `onUnmounted()`. For example, if a composable sets up a DOM event listener, it should remove that listener in `onUnmounted()` (as we have seen in the `useMouse()` example). It can also be a good idea to use a composable that automatically does this for you, like the `useEventListener()` example.
+- `onUnmounted()`에서 사이드 이펙트를 마무리 지었는지 확인하십시오.
+  예를 들어, 구성화 코드에서 DOM 이벤트 리스너를 사용하는 경우, `onUnmounted()`에서 해당 리스너를 제거해야 합니다([`useMouse()`](#마우스-위치-추적기-예제) 예제에서 본 것처럼).
+  [`useEventListener()`](#use-event-listener) 예제와 같이 자동으로 이를 수행하는 구성화 코드를 구성하는 것도 좋은 아이디어일 수 있습니다.
 
-### Usage Restrictions
+### 제한사항
 
-Composables should only be called **synchronously** in `<script setup>` or the `setup()` hook. In some cases, you can also call them in lifecycle hooks like `onMounted()`.
+구성화는 `<script setup>` 또는 `setup()` 훅에서만 **동기적으로** 호출되어야 합니다.
+어떤 경우에는 `onMounted()`와 같은 수명주기 훅에서 호출할 수도 있습니다.
 
-These are the contexts where Vue is able to determine the current active component instance. Access to an active component instance is necessary so that:
+이것들은 Vue가 현재 활성 컴포넌트 인스턴스가 무엇인지 알 수 있는 컨텍스트입니다.
+활성 컴포넌트 인스턴스에 대한 접근은 다음과 같은 작업을 위해 필요합니다:
 
-1. Lifecycle hooks can be registered to it.
+1. 수명주기 훅을 등록할 수 있다.
 
-2. Computed properties and watchers can be linked to it for disposal on component unmount.
+2. 계산된 속성과 감시자는 컴포넌트 마운트 해제 시, 관련 작업을 처리하기 위해 연결될 수 있다.
 
 :::tip
-`<script setup>` is the only place where you can call composables **after** usage of `await`. The compiler automatically restores the active instance context after the async operation for you.
+`<script setup>`은 `await`를 사용한 **후** 구성화 함수를 호출할 수 있는 유일한 곳입니다.
+컴파일러는 비동기 작업 후 활성 인스턴스 컨텍스트를 자동으로 복원합니다.
 :::
 
-## Extracting Composables for Code Organization
+## 체계적인 코드를 만들기 위해 구성화하기
 
-Composables can be extracted not only for reuse, but also for code organization. As the complexity of your components grow, you may end up with components that are too large to navigate and reason about. Composition API gives you the full flexibility to organize your component code into smaller functions based on logical concerns:
+구성화는 재사용뿐만 아니라 코드 체계화를 위해 추출할 수 있습니다.
+컴포넌트의 복잡성이 증가함에 따라 탐색 및 추론하기에 너무 큰 컴포넌트가 생길 수 있습니다.
+컴포지션 API는 논리적 문제를 기반으로 컴포넌트 코드를 더 작은 기능으로 구성할 수 있는 완전한 유연성을 제공합니다:
 
 ```vue
 <script setup>
@@ -308,11 +358,11 @@ const { qux } = useFeatureC(baz)
 </script>
 ```
 
-To some extent, you can think of these extracted composables as component-scoped services that can talk to one another.
+이렇게 추출된 구성화 코드는 협업을 위해 컴포넌트 범위 내에서 제공할 수 있습니다.
 
-## Using Composables in Options API
+## 옵션 API에서 구성화 적용
 
-If you are using Options API, composables must be called inside `setup()`, and the returned bindings must be returned from `setup()` so that they are exposed to `this` and the template:
+옵션 API를 사용하는 경우, 구성화 함수는 `setup()` 내에서 호출되어야 하고 반환된 바인딩은 `this`와 템플릿에 노출되도록 `setup()`에서 반환되어야 합니다:
 
 ```js
 import { useMouse } from './mouse.js'
@@ -325,42 +375,64 @@ export default {
     return { x, y, data, error }
   },
   mounted() {
-    // setup() exposed properties can be accessed on `this`
+    // setup()에서 노출된 속성은 `this`에서 접근할 수 있습니다.
     console.log(this.x)
   }
-  // ...other options
+  // ...다른 옵션 코드 로직
 }
 ```
 
-## Comparisons with Other Techniques
+## 다른 기술과의 비교
 
 ### vs. Mixins
 
-Users coming from Vue 2 may be familiar with the [mixins](/api/options-composition.html#mixins) option, which also allows us to extract component logic into reusable units. There are three primary drawbacks to mixins:
+Vue 2를 사용한 개발자는 [mixins](/api/options-composition.html#mixins) 옵션에 익숙할 것입니다.
+이 옵션을 사용해 컴포넌트 로직을 재사용 가능한 단위로 추출할 수도 있습니다.
+mixins에는 세 가지 주요 단점이 있습니다:
 
-1. **Unclear source of properties**: when using many mixins, it becomes unclear which instance property is injected by which mixin, making it difficult to trace the implementation and understand the component's behavior. This is also why we recommend using the refs + destructure pattern for composables: it makes the property source clear in consuming components.
+1. **불분명한 출처의 속성**:
+   많은 mixins를 사용할 때, 어떤 인스턴스 속성이 어떤 mixins에 의해 주입되는지 명확하지 않아 구현을 추적하고 컴포넌트의 동작을 이해하기 어렵습니다.
+   이것이 구성화에 refs + destructure 패턴을 사용하는 것을 권장하는 이유이기도 합니다.
+   컴포넌트가 속성을 사용할 때 그 출처를 명확하게 만듭니다.
 
-2. **Namespace collisions**: multiple mixins from different authors can potentially register the same property keys, causing namespace collisions. With composables, you can rename the destructured variables if there are conflicting keys from different composables.
+2. **네임스페이스 충돌**:
+   다른 작성자의 여러 mixins이 잠재적으로 동일한 속성 키를 등록하여 네임스페이스 충돌을 일으킬 수 있습니다.
+   구성화를 사용하면 다른 구성화와 충돌하는 키가 있는 경우 분해 할당 문법으로 변수의 이름을 바꿀 수 있습니다.
 
-3. **Implicit cross-mixin communication**: multiple mixins that need to interact with one another have to rely on shared property keys, making them implicitly coupled. With composables, values returned from one composable can be passed into another as arguments, just like normal functions.
+3. **암시적 mixins 간 통신**:
+   서로 상호 작용해야 하는 여러 mixins은 공유 속성 키에 의존해야 하므로 암시적으로 결합됩니다.
+   구성화를 사용하면 일반 함수와 마찬가지로 한 구성화에서 반환된 값을 다른 구성화에 인수로 전달할 수 있습니다.
 
-For the above reasons, we no longer recommend using mixins in Vue 3. The feature is kept only for migration and familiarity reasons.
+위의 이유로 Vue 3에서는 더 이상 mixins를 사용하지 않는 것이 좋습니다.
+이 기능은 마이그레이션 및 익숙함을 위해서만 유지됩니다.
 
-### vs. Renderless Components
+### vs. 렌더리스 컴포넌트
 
-In the component slots chapter, we discussed the [Renderless Component](/guide/components/slots.html#renderless-components) pattern based on scoped slots. We even implemented the same mouse tracking demo using renderless components.
+컴포넌트 심화의 슬롯 챕터에서는 범위가 지정된 슬롯을 기반으로 하는 [렌더리스 컴포넌트](/guide/components/slots.html#렌더리스-컴포넌트) 패턴에 대해 논의했습니다.
+렌더리스 컴포넌트를 사용하여 동일한 마우스 추적 데모도 구현했습니다.
 
-The main advantage of composables over renderless components is that composables do not incur the extra component instance overhead. When used across an entire application, the amount of extra component instances created by the renderless component pattern can become a noticeable performance overhead.
+렌더리스 컴포넌트에 비해 구성화의 주요 이점은 구성화가 추가적인 컴포넌트 인스턴스 오버헤드를 발생시키지 않는다는 것입니다.
+전체 앱에서 사용될 때 렌더리스 컴포넌트 패턴에 의해 생성된 추가 컴포넌트 인스턴스의 양이 눈에 띄게 성능 오버헤드가 될 수 있습니다.
 
-The recommendation is to use composables when reusing pure logic, and use components when reusing both logic and visual layout.
+권장 사항은 순수 로직을 재사용할 때 구성화를 사용하고 로직과 시각적 레이아웃을 모두 재사용할 때 컴포넌트를 사용하는 것입니다.
 
-### vs. React Hooks
+### vs. React 훅
 
-If you have experience with React, you may notice that this looks very similar to custom React hooks. Composition API was in part inspired by React hooks, and Vue composables are indeed similar to React hooks in terms of logic composition capabilities. However, Vue composables are based on Vue's fine-grained reactivity system, which is fundamentally different from React hooks' execution model. This is discussed in more details in the [Composition API FAQ](/guide/extras/composition-api-faq#comparison-with-react-hooks).
+React에 대한 경험이 있다면 이것이 커스텀 React 훅과 매우 유사하다는 것을 알 수 있습니다.
+컴포지션 API는 부분적으로 React 훅에서 영감을 얻었고 Vue 구성화는 실제로 로직 구성 기능 측면에서 React 훅와 유사합니다.
+그러나 Vue 구성화는 Vue의 세분화된 반응성 시스템을 기반으로 하며, 이는 React 훅의 실행 모델과 근본적으로 다릅니다.
+이는 [컴포지션 API FAQ](/guide/extras/composition-api-faq#comparison-with-react-hooks)에서 자세히 설명합니다.
 
-## Further Reading
+[comment]: <> (/guide/extras/composition-api-faq.md 번역 후 링크 수정 필요)
 
-- [Reactivity In Depth](/guide/extras/reactivity-in-depth.html): for a low-level understanding of how Vue's reactivity system works.
-- [State Management](/guide/scaling-up/state-management.html): for patterns of managing state shared by multiple components.
-- [Testing Composables](/guide/scaling-up/testing.html#testing-composables): tips on unit testing composables.
-- [VueUse](https://vueuse.org/): an ever-growing collection of Vue composables. The source code is also a great learning resource.
+## 추가적인 읽을거리
+
+- [반응형 심화](/guide/extras/reactivity-in-depth.html): Vue의 반응형 시스템이 어떻게 작동하는지에 대한 심화 수준의 이해를 위해.
+
+- [상태 관리](/guide/scaling-up/state-management.html): 여러 컴포넌트가 공유하는 상태를 관리하는 패턴입니다.
+
+- [테스팅 구성화](/guide/scaling-up/testing.html#testing-composables): 단위 테스트 구성화에 대한 팁.
+
+[comment]: <> (/guide/scaling-up/testing.md 번역 후 링크 수정 필요)
+
+- [VueUse](https://vueuse.org/): 계속 증가하는 Vue 구성화 컬렉션입니다. 또한 소스 코드는 훌륭한 학습 자료입니다.

--- a/ko-KR/src/guide/reusability/custom-directives.md
+++ b/ko-KR/src/guide/reusability/custom-directives.md
@@ -1,7 +1,4 @@
-:::warning 현재 이 문서는 번역 작업이 진행중입니다
-:::
-
-# Custom Directives
+# 커스텀 지시문
 
 <script setup>
 const vFocus = {
@@ -11,19 +8,23 @@ const vFocus = {
 }
 </script>
 
-## Introduction
+## 소개
 
-In addition to the default set of directives shipped in core (like `v-model` or `v-show`), Vue also allows you to register your own custom directives.
+코어에 포함된 기본 지시문 세트(예: `v-model` 또는 `v-show`) 외에도 Vue를 사용하면 커스텀 지시문을 정의할 수 있습니다.
 
-We have introduced two forms of code reuse in Vue: [components](/guide/essentials/component-basics.html) and [composables](./composables). Components are the main building blocks, while composables are focused on reusing stateful logic. Custom directives, on the other hand, are mainly intended for reusing logic that involves low-level DOM access on plain elements.
+우리는 Vue에서 [컴포넌트 기초](/guide/essentials/component-basics.html)와 [구성화](./composables)라는 두 가지 형태의 코드 재사용을 도입했습니다.
+컴포넌트는 주요 구성-요소(building-block)이고, 구성화는 상태 저장 로직을 재사용하는 데 중점을 둡니다.
+반면에 커스텀 지시문은 주로 일반 엘리먼트에 대한 저수준(low-level) DOM 접근과 관련된 로직을 재사용하기 위한 것입니다.
 
-A custom directive is defined as an object containing lifecycle hooks similar to those of a component. The hooks receive the element the directive is bound to. Here is an example of a directive that focuses an input when the element is inserted into the DOM by Vue:
+커스텀 지시문은 컴포넌트의 수명주기 훅을 포함하는 객체처럼 정의됩니다.
+훅은 지시문이 바인딩된 엘리먼트를 수신합니다.
+다음은 엘리먼트가 Vue에 의해 DOM에 삽입될 때, `<input>`에 포커스 되는 커스텀 지시문 구현의 예제입니다:
 
 <div class="composition-api">
 
 ```vue
 <script setup>
-// enables v-focus in templates
+// 템플릿에서 v-focus로 활성화 가능
 const vFocus = {
   mounted: (el) => el.focus()
 }
@@ -45,7 +46,7 @@ const focus = {
 
 export default {
   directives: {
-    // enables v-focus in template
+    // 템플릿에서 v-focus로 활성화 가능
     focus
   }
 }
@@ -58,16 +59,18 @@ export default {
 </div>
 
 <div class="demo">
-  <input v-focus placeholder="This should be focused" />
+  <input v-focus placeholder="포커스 되어야 함" />
 </div>
 
-Assuming you haven't clicked elsewhere on the page, the input above should be auto-focused. This directive is more useful than the `autofocus` attribute because it works not just on page load - it also works when the element is dynamically inserted by Vue.
+페이지의 다른 곳을 클릭하지 않았다고 가정하면, 위의 인풋은 자동으로 포커스 되어야 합니다.
+이 지시문은 페이지 로드 시 뿐만 아니라, Vue에서 동적으로 엘리먼트를 삽입할 때도 작동하기 때문에 `autofocus` 속성보다 더 유용합니다.
 
 <div class="composition-api">
 
-In `<script setup>`, any camelCase variable that starts with the `v` prefix can be used as a custom directive. In the example above, `vFocus` can be used in the template as `v-focus`.
+`<script setup>`에서 `v` 접두사로 시작하는 모든 camelCase 변수를 커스텀 지시문으로 사용할 수 있습니다.
+위의 예에서 `vFocus`는 템플릿에서 `v-focus`로 사용할 수 있습니다.
 
-If not using `<script setup>`, custom directives can be registered using the `directives` option:
+`<script setup>`을 사용하지 않는 경우, `directives` 옵션을 사용하여 커스텀 지시문을 등록할 수 있습니다:
 
 ```js
 export default {
@@ -75,7 +78,7 @@ export default {
     /*...*/
   },
   directives: {
-    // enables v-focus in template
+    // 템플릿에서 v-focus로 활성화 가능
     focus: {
       /* ... */
     }
@@ -87,103 +90,108 @@ export default {
 
 <div class="options-api">
 
-Similar to components, custom directives must be registered so that they can be used in templates. In the example above, we are using local registration via the `directives` option.
+컴포넌트와 마찬가지로 커스텀 지시문은 템플릿에서 사용할 수 있도록 등록해야 합니다.
+위의 예에서는 `directives` 옵션을 통해 로컬 등록을 사용하고 있습니다.
 
 </div>
 
-It is also common to globally register custom directives at the app level:
+앱 수준에서 커스텀 지시문을 전역적으로 등록하는 것도 일반적입니다:
 
 ```js
 const app = createApp({})
 
-// make v-focus usable in all components
+// 모든 컴포넌트에서 v-focus를 사용할 수 있도록 합니다.
 app.directive('focus', {
   /* ... */
 })
 ```
 
 :::tip
-Custom directives should only be used when the desired functionality can only be achieved via direct DOM manipulation. Prefer declarative templating using built-in directives such as `v-bind` when possible because they are more efficient and server-rendering friendly.
+커스텀 지시문은 원하는 기능을 직접 DOM 조작을 통해서만 달성할 수 있는 경우에만 사용해야 합니다.
+가능하면 `v-bind`와 같은 내장 지시문을 사용하여 선언적 템플릿을 사용하는 것이 더 효율적이고 서버 렌더링에 친숙하기 때문입니다.
 :::
 
-## Directive Hooks
+## 지시문 훅
 
-A directive definition object can provide several hook functions (all optional):
+지시문을 정의하는 객체는 다음과 같은 여러 훅 기능을 제공할 수 있습니다(모두 선택 사항):
 
 ```js
 const myDirective = {
-  // called before bound element's attributes
-  // or event listeners are applied
+  // 바인딩된 엘리먼트의 속성 또는
+  // 이벤트 리스너가 적용되기 전에 호출됩니다.
   created(el, binding, vnode, prevVnode) {
-    // see below for details on arguments
+    // 인자에 대한 자세한 내용은 아래를 참조.
   },
-  // called right before the element is inserted into the DOM.
+  // 엘리먼트가 DOM에 삽입되기 직전에 호출됩니다.
   beforeMount() {},
-  // called when the bound element's parent component
-  // and all its children are mounted.
+  // 바인딩된 엘리먼트의 부모 컴포넌트 및
+  // 모든 자식 컴포넌트의 mounted 이후에 호출됩니다.
   mounted() {},
-  // called before the parent component is updated
+  // 부모 컴포넌트의 updated 전에 호출됩니다.
   beforeUpdate() {},
-  // called after the parent component and
-  // all of its children have updated
+  // 바인딩된 엘리먼트의 부모 컴포넌트 및
+  // 모든 자식 컴포넌트의 updated 이후에 호출됩니다.
   updated() {},
-  // called before the parent component is unmounted
+  // 부모 컴포넌트의 beforeUnmount 이후에 호출됩니다.
   beforeUnmount() {},
-  // called when the parent component is unmounted
+  // 부모 컴포넌트의 unmounted 전에 호출됩니다.
   unmounted() {}
 }
 ```
 
-### Hook Arguments
+### 훅 인자
 
-Directive hooks are passed these arguments:
+지시문 훅에는 다음 인자가 전달됩니다:
 
-- `el`: the element the directive is bound to. This can be used to directly manipulate the DOM.
+- `el`: 지시문이 바인딩된 엘리먼트입니다. DOM을 직접 조작하는 데 사용할 수 있습니다.
 
-- `binding`: an object containing the following properties.
+- `binding`: 다음 속성을 포함하는 객체입니다.
 
-  - `value`: The value passed to the directive. For example in `v-my-directive="1 + 1"`, the value would be `2`.
-  - `oldValue`: The previous value, only available in `beforeUpdate` and `updated`. It is available whether or not the value has changed.
-  - `arg`: The argument passed to the directive, if any. For example in `v-my-directive:foo`, the arg would be `"foo"`.
-  - `modifiers`: An object containing modifiers, if any. For example in `v-my-directive.foo.bar`, the modifiers object would be `{ foo: true, bar: true }`.
-  - `instance`: The instance of the component where the directive is used.
-  - `dir`: the directive definition object.
+  - `value`: 지시문에 전달된 값입니다. 예를 들어 `v-my-directive="1 + 1"`에서 value는 `2`입니다.
+  - `oldValue`: 이것은 `beforeUpdate` 및 `updated`에서만 사용할 수 있습니다. 값이 변경되었는지 여부에 관계없이 사용 가능합니다.
+  - `arg`: 지시문에 전달된 인자(있는 경우). 예를 들어 `v-my-directive:foo`에서 인자는 `"foo"`입니다.
+  - `modifiers`: 수식어가 있는 경우 수식어를 포함하는 객체입니다. 예를 들어 `v-my-directive.foo.bar`에서 수식어 객체는 `{ foo: true, bar: true }`입니다.
+  - `instance`: 지시문이 사용되는 컴포넌트의 인스턴스입니다.
+  - `dir`: 지시문을 정의하는 객체
 
-- `vnode`: the underlying VNode representing the bound element.
-- `prevNode`: the VNode representing the bound element from the previous render. Only available in the `beforeUpdate` and `updated` hooks.
+- `vnode`: 바인딩된 엘리먼트를 나타내는 기본 VNode.
+- `prevNode`: 이전 렌더링에서 바인딩된 엘리먼트를 나타내는 VNode입니다. `beforeUpdate` 및 `updated` 훅에서만 사용할 수 있습니다.
 
-As an example, consider the following directive usage:
+다음과 같은 지시문을 사용한다고 가정한 예제를 살펴봅시다:
 
 ```vue-html
 <div v-example:foo.bar="baz">
 ```
 
-The `binding` argument would be an object in the shape of:
+`binding` 인자는 다음과 같은 형태의 객체입니다:
 
 ```js
 {
   arg: 'foo',
   modifiers: { bar: true },
-  value: /* value of `baz` */,
-  oldValue: /* value of `baz` from previous update */
+  value: /* `baz`의 값 */,
+  oldValue: /* 업데이트 전 `baz`의 값 */
 }
 ```
 
-Similar to built-in directives, custom directive arguments can be dynamic. For example:
+내장 지시문과 유사하게 커스텀 지시문 인수는 동적일 수 있습니다.
+예를 들어:
 
 ```vue-html
 <div v-example:[arg]="value"></div>
 ```
 
-Here the directive argument will be reactively updated based on `arg` property in our component state.
+여기서 지시문 인자는 컴포넌트 상태의 `arg` 속성을 기반으로 반응형으로 업데이트됩니다.
 
-:::tip Note
-Apart from `el`, you should treat these arguments as read-only and never modify them. If you need to share information across hooks, it is recommended to do so through element's [dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset).
+:::tip 참고
+`el`을 제외하고 이러한 인수들은 읽기 전용으로 처리하고 절대 수정해서는 안 됩니다.
+훅 간에 정보를 공유해야 하는 경우 엘리먼트의 [dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset)을 통해 공유하는 것이 좋습니다.
 :::
 
-## Function Shorthand
+## 간단하게 함수로 사용하기
 
-It's common for a custom directive to have the same behavior for `mounted` and `updated`, with no need for the other hooks. In such cases we can define the directive as a function:
+커스텀 지시문이 `mounted` 및 `updated`에 대해 동일한 동작을 갖는 것이 일반적이며, 다른 훅은 필요하지 않습니다.
+이러한 경우 지시문을 객체가 아닌 함수로 정의할 수 있습니다:
 
 ```vue-html
 <div v-color="color"></div>
@@ -191,40 +199,44 @@ It's common for a custom directive to have the same behavior for `mounted` and `
 
 ```js
 app.directive('color', (el, binding) => {
-  // this will be called for both `mounted` and `updated`
+  // 이 함수가 호출되는 시점은 `mounted`와 `updated`입니다.
   el.style.color = binding.value
 })
 ```
 
-## Object Literals
+## 객체를 값으로 전달하기
 
-If your directive needs multiple values, you can also pass in a JavaScript object literal. Remember, directives can take any valid JavaScript expression.
+지시문에 여러 값이 필요한 경우, JavaScript 객체 리터럴을 전달할 수도 있습니다.
+지시문은 모든 유효한 JavaScript 표현식을 사용할 수 있음을 기억하십시오.
 
 ```vue-html
-<div v-demo="{ color: 'white', text: 'hello!' }"></div>
+<div v-demo="{ color: 'white', text: '안녕!' }"></div>
 ```
 
 ```js
 app.directive('demo', (el, binding) => {
   console.log(binding.value.color) // => "white"
-  console.log(binding.value.text) // => "hello!"
+  console.log(binding.value.text) // => "안녕!"
 })
 ```
 
-## Usage on Components
+## 컴포넌트에서 사용
 
-When used on components, custom directives will always apply to a component's root node, similar to [Fallthrough Attributes](/guide/components/attrs.html).
+컴포넌트에 사용될 때 커스텀 지시문은 [폴스루 속성](/guide/components/attrs.html)과 유사하게 항상 컴포넌트의 루트 노드에 적용됩니다.
 
 ```vue-html
 <MyComponent v-demo="test" />
 ```
 
 ```vue-html
-<!-- template of MyComponent -->
+<!-- MyComponent 템플릿에서 -->
 
-<div> <!-- v-demo directive will be applied here -->
-  <span>My component content</span>
+<div> <!-- 여기에 v-demo 지시문이 적용됩니다. -->
+  <span>컴포넌트 컨텐츠...</span>
 </div>
 ```
 
-Note that components can potentially have more than one root node. When applied to a multi-root component, a directive will be ignored and a warning will be thrown. Unlike attributes, directives can't be passed to a different element with `v-bind="$attrs"`. In general, it is **not** recommended to use custom directives on components.
+컴포넌트에는 잠재적으로 둘 이상의 루트 노드가 있을 수 있습니다.
+다중 루트 컴포넌트에 적용하려고 하면 지시문이 무시되고 애러가 발생합니다.
+속성과 달리 지시문은 `v-bind="$attrs"`를 사용하여 다른 엘리먼트에 전달할 수 없습니다.
+일반적으로 컴포넌트에 커스텀 지시문을 사용하는 것은 **권장되지 않습니다**.

--- a/ko-KR/src/guide/reusability/plugins.md
+++ b/ko-KR/src/guide/reusability/plugins.md
@@ -1,12 +1,9 @@
-﻿:::warning 현재 이 문서는 번역 작업이 진행중입니다
-:::
+﻿# 플러그인
 
+## 소개
 
-# Plugins
-
-## Introduction
-
-Plugins are self-contained code that usually add app-level functionality to Vue. This is how we install a plugin:
+플러그인은 일반적으로 Vue에 앱 레벨 기능을 추가하는 자체 코드입니다.
+플러그인을 설치하는 방법은 다음과 같습니다:
 
 ```js
 import { createApp } from 'vue'
@@ -14,55 +11,58 @@ import { createApp } from 'vue'
 const app = createApp({})
 
 app.use(myPlugin, {
-  /* optional options */
+  /* 선택적인 옵션 */
 })
 ```
 
-A plugin is defined as either an object that exposes an `install()` method, or simply a function that acts as the install function itself. The install function receives the [app instance](/api/application.html) along with additional options passed to `app.use()`, if any:
+플러그인은 `install()` 메소드를 노출하는 객체 또는 단순히 install 함수 자체로 작동하는 함수로 정의됩니다.
+install 함수는 `app.use()`에 전달된 추가 옵션과 함께 [앱 인스턴스](/api/application.html)를 받습니다(있는 경우):
 
 ```js
 const myPlugin = {
   install(app, options) {
-    // configure the app
+    // 앱 환경설정
   }
 }
 ```
 
-There is no strictly defined scope for a plugin, but common scenarios where plugins are useful include:
+플러그인에 대해 엄격하게 정의된 범위는 없지만 플러그인이 유용한 일반적인 시나리오는 다음과 같습니다:
 
-1. Register one or more global components or custom directives with [`app.component()`](/api/application.html#app-component) and [`app.directive()`](/api/application.html#app-directive).
+1. [`app.component()`](/api/application.html#app-component) 및 [`app.directive()`](/api/application.html#app-directive)를 사용하여 하나 이상의 전역 컴포넌트 또는 커스텀 지시문을 등록합니다.
 
-2. Make a resource [injectable](/guide/components/provide-inject.html) throughout the app by calling [`app.provide()`](/api/application.html#app-provide).
+2. [`app.provide()`](/api/application.html#app-provide)를 호출하여 앱 전체에 리소스를 [주입 가능](/guide/components/provide-inject.html)하게 만듭니다.
 
-3. Add some global instance properties or methods by attaching them to [`app.config.globalProperties`](/api/application.html#app-config-globalproperties).
+3. 일부 전역 인스턴스 속성 또는 메서드를 [`app.config.globalProperties`](/api/application.html#app-config-globalproperties)에 첨부하여 추가합니다.
 
-4. A library that needs to perform some combination of the above (e.g. [vue-router](https://github.com/vuejs/vue-router-next)).
+4. 위 목록의 몇 가지를 조합해 무언가를 수행해야 하는 라이브러리(예: [vue-router](https://github.com/vuejs/vue-router-next)).
 
-## Writing a Plugin
+## 플러그인 작성하기
 
-In order to better understand how to create your own Vue.js plugins, we will create a very simplified version of a plugin that displays `i18n` (short for [Internationalization](https://en.wikipedia.org/wiki/Internationalization_and_localization)) strings.
+고유한 Vue.js 플러그인을 만드는 방법을 더 잘 이해하기 위해 `i18n`([Internationalization](https://en.wikipedia.org/wiki/Internationalization_and_localization)의 약어) 문자열을 표시하는 매우 간단한 버전의 플러그인을 만들 것입니다.
 
-Let's begin by setting up the plugin object. It is recommended to create it in a separate file and export it, as shown below to keep the logic contained and separate.
+플러그인 객체를 설정하는 것으로 시작하겠습니다.
+로직이 포함되고 분리된 상태로 유지하려면 아래와 같이 별도의 파일로 생성하여 내보내는 것이 좋습니다.
 
 ```js
 // plugins/i18n.js
 export default {
   install: (app, options) => {
-    // Plugin code goes here
+    // 플러그인 코드는 여기로
   }
 }
 ```
 
-We want to make a function to translate keys available to the whole application, so we will expose it using `app.config.globalProperties`. This function will receive a dot-delimited `key` string, which we will use to look up the translated string in the user-provided options.
+우리는 앱 전체에서 사용할 수 있는 키를 번역하는 기능을 만들고자 하므로 `app.config.globalProperties`를 사용하여 이를 노출할 것입니다.
+이 함수는 점으로 구분된 `key` 문자열을 수신하며, 커스텀 옵션에서 번역된 문자열을 찾는 데 사용할 것입니다.
 
 ```js{4-11}
 // plugins/i18n.js
 export default {
   install: (app, options) => {
-    // inject a globally available $translate() method
+    // 전역적으로 사용 가능한 $translate() 메소드 주입
     app.config.globalProperties.$translate = (key) => {
-      // retrieve a nested property in `options`
-      // using `key` as the path
+      // `key`를 경로로 사용하여
+      // `options`에서 중첩 속성을 검색합니다.
       return key.split('.').reduce((o, i) => {
         if (o) return o[i]
       }, options)
@@ -71,7 +71,7 @@ export default {
 }
 ```
 
-The plugin expects users to pass in an object containing the translated keys via the options when they use the plugin, so it should be used like this:
+플러그인은 사용자가 플러그인을 사용할 때 옵션을 통해 번역된 키가 포함된 객체를 전달할 것으로 예상하므로 다음과 같이 사용해야 합니다:
 
 ```js
 import i18nPlugin from './plugins/i18n'
@@ -83,21 +83,24 @@ app.use(i18nPlugin, {
 })
 ```
 
-Our `$translate` function will take a string such as `greetings.hello`, look inside the user provided configuration and return the translated value - in this case, `Bonjour!`:
+우리의 `$translate` 함수는 `greetings.hello`와 같은 문자열을 사용하여 사용자가 제공한 구성을 살펴보고 번역된 값을 반환합니다.
+이 경우에는 `Bonjour!`입니다.
 
 ```vue-html
 <h1>{{ $translate('greetings.hello') }}</h1>
 ```
 
-See also: [Augmenting Global Properties](/guide/typescript/options-api.html#augmenting-global-properties) <sup class="vt-badge ts" />
+참조: [전역 속성 타입 보완하기](/guide/typescript/options-api.html#augmenting-global-properties) <sup class="vt-badge ts" />
 
 :::tip
-Use global properties scarcely, since it can quickly become confusing if too many global properties injected by different plugins are used throughout an app.
+왠만하면 전역 속성은 사용하지 마십시오.
+앱 전체에서 다른 플러그인에 의해 주입된 전역 속성이 너무 많이 사용되면 혼란스러워질 수 있기 때문입니다.
 :::
 
-### Provide / Inject with Plugins
+### 플러그인에서 Provide / Inject 활용하기
 
-Plugins also allow us to use `inject` to provide a function or attribute to the plugin's users. For example, we can allow the application to have access to the `options` parameter to be able to use the translations object.
+플러그인을 사용하면 `inject`를 사용하여 플러그인 사용자에게 함수나 속성을 제공할 수도 있습니다.
+예를 들어 앱이 `options` 매개변수에 접근하여 번역 객체를 사용할 수 있도록 허용할 수 있습니다.
 
 ```js{10}
 // plugins/i18n.js
@@ -114,7 +117,7 @@ export default {
 }
 ```
 
-Plugin users will now be able to inject the plugin options into their components using the `i18n` key:
+플러그인 사용자는 이제 `i18n` 키를 사용하여 컴포넌트에 플러그인 옵션을 삽입할 수 있습니다:
 
 <div class="composition-api">
 


### PR DESCRIPTION
 - 문서 전체 번역
 - 가이드 한글화

참고:
배포 빌드 애러 날 경우,
본문 제목이 영문에서 한글로 바뀌어서
앵커링크가 변경되어서 일듯 합니다.
(ex: `./my#link` → `./my#링크`)