### PR TITLE
수정: API 메인 페이지 링크 텍스트 한글 적용

### DIFF
--- a/ko-KR/src/api/ApiIndex.vue
+++ b/ko-KR/src/api/ApiIndex.vue
@@ -95,7 +95,7 @@ function slugify(text: string): string {
           <h3>{{ item.text }}</h3>
           <ul>
             <li v-for="h of item.headers" :key="h.anchor">
-              <a :href="item.link + '.html#' + slugify(h.anchor)">{{ h.anchor }}</a>
+              <a :href="item.link + '.html#' + slugify(h.anchor)">{{ h.text }}</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
API 메인 페이지 링크 텍스트가 커스텀 앵커로 출력되는 이슈 수정